### PR TITLE
Fix thread safety -- this time for real (hopefully)

### DIFF
--- a/Source/PrisonCommons/PrisonCommons.cs
+++ b/Source/PrisonCommons/PrisonCommons.cs
@@ -74,7 +74,7 @@ public static class PrisonCommons
         while (doorQueue.Count != 0)
         {
             var door = doorQueue.Dequeue();
-            foreach (var neighbor in door.Districts[0].Neighbors)
+            foreach (var neighbor in door.Districts[0].Regions[0].Neighbors)
             {
                 var neighborRoom = neighbor.Room;
 


### PR DESCRIPTION
The vanilla property ``District.Neighbors`` is not thread-safe due to using non-thread-safe containers, and while this race-condition is much rarer compared to before my last PR https://github.com/emipa606/PrisonCommons/pull/3, it still happened in my game after a dozen hours with ~10 prisoner pawns sharing a room.

A door is a ``Room`` which has exactly one ``District`` with exactly one ``Region`` (see the vanilla implementation of ``Verse.Room.IsDoorway``), so we can get ``door.Districts[0].Regions[0].Neighbors`` instead of ``door.Districts[0].Neighbors``, as ``Region.Neighbors`` appears thread-safe to me.

This does skip some of the other checks in ``District.Neighbors``, but from my reading of vanilla code, none of them seem relevant to our doors (we don't need the duplication checks within ``District.Neighbors`` because we are already doing it with our Hashset ``seenDoors`` and ``firstMatchingRoom`` from https://github.com/emipa606/PrisonCommons/pull/3), so I believe they were redundant anyways, and this should turn out to be a performance improvement (by removing redundant code) in addition to being a bugfix.

The only unsolved question I have is that the vanilla's implementation of the property ``Verse.Region.Room`` seems to suggest that a ``Region`` might have a null ``District`` or ``Room``, but if that's true, then that we should have seen null ref errors with the original solutions (before this PR, and before https://github.com/emipa606/PrisonCommons/pull/3) too, and I don't think anyone reported null refs here. We can easily add a null check for ``var neighborRoom`` to mitigate this though.

Anyways, I play-tested this a bit more after implementing this change and saw no further errors, so this small change should be safe.